### PR TITLE
Add Links field to unmarshal from Magellan power info

### DIFF
--- a/schemas/inventory.go
+++ b/schemas/inventory.go
@@ -54,30 +54,30 @@ type Links struct {
 }
 
 type InventoryDetail struct {
-	URI                  string                 `json:"uri,omitempty"`                  // URI of the BMC
-	UUID                 string                 `json:"uuid,omitempty"`                 // UUID of Node
-	Manufacturer         string                 `json:"manufacturer,omitempty"`         // Manufacturer of the Node
-	SystemType           string                 `json:"system_type,omitempty"`          // System type of the Node
-	Name                 string                 `json:"name,omitempty"`                 // Name of the Node
-	Model                string                 `json:"model,omitempty"`                // Model of the Node
-	Serial               string                 `json:"serial,omitempty"`               // Serial number of the Node
-	BiosVersion          string                 `json:"bios_version,omitempty"`         // Version of the BIOS
-	EthernetInterfaces   []EthernetInterface    `json:"ethernet_interfaces,omitempty"`  // Ethernet interfaces of the Node
-	NetworkInterfaces    []NetworkInterface     `json:"network_interfaces,omitempty"`   // Network interfaces of the Node
-	PowerState           string                 `json:"power_state,omitempty"`          // Power state of the Node
-	ProcessorCount       int                    `json:"processor_count,omitempty"`      // Processors of the Node
-	ProcessorType        string                 `json:"processor_type,omitempty"`       // Processor type of the Node
-	MemoryTotal          float32                `json:"memory_total,omitempty"`         // Total memory of the Node in Gigabytes
-	TrustedModules       []string               `json:"trusted_modules,omitempty"`      // Trusted modules of the Node
-	TrustedComponents    []string               `json:"trusted_components,omitempty"`   // Trusted components of the Chassis
-	Chassis_SKU          string                 `json:"chassis_sku,omitempty"`          // SKU of the Chassis
-	Chassis_Serial       string                 `json:"chassis_serial,omitempty"`       // Serial number of the Chassis
-	Chassis_AssetTag     string                 `json:"chassis_asset_tag,omitempty"`    // Asset tag of the Chassis
-	Chassis_Manufacturer string                 `json:"chassis_manufacturer,omitempty"` // Manufacturer of the Chassis
-	Chassis_Model        string                 `json:"chassis_model,omitempty"`        // Model of the Chassis
-	OdataId              string                 `json:"@odata.id,omitempty"`            // OData ID for the computer system
-	PowerURL             string                 `json:"PowerURL,omitempty"`             // URL for power control
-	PowerControl         []*PowerControl        `json:"PowerControl,omitempty"`         // Power control actions data
-	Actions              *ComputerSystemActions `json:"Actions,omitempty"`              // Actions for the hardware
-	Links                *Links                 `json:"links,omitempty"`                // Links to related resources
+	URI                  string              `json:"uri,omitempty"`                  // URI of the BMC
+	UUID                 string              `json:"uuid,omitempty"`                 // UUID of Node
+	Manufacturer         string              `json:"manufacturer,omitempty"`         // Manufacturer of the Node
+	SystemType           string              `json:"system_type,omitempty"`          // System type of the Node
+	Name                 string              `json:"name,omitempty"`                 // Name of the Node
+	Model                string              `json:"model,omitempty"`                // Model of the Node
+	Serial               string              `json:"serial,omitempty"`               // Serial number of the Node
+	BiosVersion          string              `json:"bios_version,omitempty"`         // Version of the BIOS
+	EthernetInterfaces   []EthernetInterface `json:"ethernet_interfaces,omitempty"`  // Ethernet interfaces of the Node
+	NetworkInterfaces    []NetworkInterface  `json:"network_interfaces,omitempty"`   // Network interfaces of the Node
+	PowerState           string              `json:"power_state,omitempty"`          // Power state of the Node
+	ProcessorCount       int                 `json:"processor_count,omitempty"`      // Processors of the Node
+	ProcessorType        string              `json:"processor_type,omitempty"`       // Processor type of the Node
+	MemoryTotal          float32             `json:"memory_total,omitempty"`         // Total memory of the Node in Gigabytes
+	TrustedModules       []string            `json:"trusted_modules,omitempty"`      // Trusted modules of the Node
+	TrustedComponents    []string            `json:"trusted_components,omitempty"`   // Trusted components of the Chassis
+	Chassis_SKU          string              `json:"chassis_sku,omitempty"`          // SKU of the Chassis
+	Chassis_Serial       string              `json:"chassis_serial,omitempty"`       // Serial number of the Chassis
+	Chassis_AssetTag     string              `json:"chassis_asset_tag,omitempty"`    // Asset tag of the Chassis
+	Chassis_Manufacturer string              `json:"chassis_manufacturer,omitempty"` // Manufacturer of the Chassis
+	Chassis_Model        string              `json:"chassis_model,omitempty"`        // Model of the Chassis
+	OdataId              string              `json:"@odata.id,omitempty"`            // OData ID for the computer system
+	PowerURL             string              `json:"PowerURL,omitempty"`             // URL for power control
+	PowerControl         []*PowerControl     `json:"PowerControl,omitempty"`         // Power control actions data
+	Actions              []string            `json:"actions,omitempty"`              // Actions for the hardware
+	Links                *Links              `json:"links,omitempty"`                // Links to related resources
 }

--- a/schemas/inventory.go
+++ b/schemas/inventory.go
@@ -53,6 +53,10 @@ type Links struct {
 	Managers []string `json:"managers,omitempty"`
 }
 
+type Power struct {
+	State string `json:"state,omitempty"`
+}
+
 type InventoryDetail struct {
 	URI                  string              `json:"uri,omitempty"`                  // URI of the BMC
 	UUID                 string              `json:"uuid,omitempty"`                 // UUID of Node
@@ -64,7 +68,7 @@ type InventoryDetail struct {
 	BiosVersion          string              `json:"bios_version,omitempty"`         // Version of the BIOS
 	EthernetInterfaces   []EthernetInterface `json:"ethernet_interfaces,omitempty"`  // Ethernet interfaces of the Node
 	NetworkInterfaces    []NetworkInterface  `json:"network_interfaces,omitempty"`   // Network interfaces of the Node
-	PowerState           string              `json:"power_state,omitempty"`          // Power state of the Node
+	Power                *Power              `json:"power,omitempty"`                // Power state of the Node
 	ProcessorCount       int                 `json:"processor_count,omitempty"`      // Processors of the Node
 	ProcessorType        string              `json:"processor_type,omitempty"`       // Processor type of the Node
 	MemoryTotal          float32             `json:"memory_total,omitempty"`         // Total memory of the Node in Gigabytes

--- a/schemas/inventory.go
+++ b/schemas/inventory.go
@@ -48,6 +48,11 @@ type PowerControl struct {
 	RelatedItem        []*ResourceID `json:"RelatedItem,omitempty"`
 }
 
+type Links struct {
+	Chassis  []string `json:"chassis,omitempty"`
+	Managers []string `json:"managers,omitempty"`
+}
+
 type InventoryDetail struct {
 	URI                  string                 `json:"uri,omitempty"`                  // URI of the BMC
 	UUID                 string                 `json:"uuid,omitempty"`                 // UUID of Node
@@ -74,4 +79,5 @@ type InventoryDetail struct {
 	PowerURL             string                 `json:"PowerURL,omitempty"`             // URL for power control
 	PowerControl         []*PowerControl        `json:"PowerControl,omitempty"`         // Power control actions data
 	Actions              *ComputerSystemActions `json:"Actions,omitempty"`              // Actions for the hardware
+	Links                *Links                 `json:"links,omitempty"`                // Links to related resources
 }


### PR DESCRIPTION
This change is needed to handle the changes from https://github.com/OpenCHAMI/magellan/pull/104, which add a "links" field to the Magellan data.